### PR TITLE
Add support for formatted input

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,9 @@ libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "net.databinder" %% "dispatch-http" % "0.8.10",
   "org.json4s" %% "json4s-native" % "3.2.10",
-  "com.google.guava" % "guava" % "18.0"
+  "com.google.guava" % "guava" % "18.0",
+  "org.scalactic" %% "scalactic" % "3.0.1",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
 autoCompilerPlugins := true

--- a/src/test/scala/org/multibot/InputSanitizerTest.scala
+++ b/src/test/scala/org/multibot/InputSanitizerTest.scala
@@ -1,0 +1,25 @@
+package org.multibot
+
+import org.scalatest.{Assertion, FlatSpec}
+
+class InputSanitizerTest extends FlatSpec {
+
+  def ensureSanitizedInput(in: String, expected: String): Assertion =
+    assert(InputSanitizer.sanitize(in) === expected)
+
+  def ensureNoSanitization(in: String) : Assertion =
+    ensureSanitizedInput(in, in)
+
+  "Inputs" should "be sanitized" in {
+    ensureSanitizedInput("```foo```", "foo")
+    ensureSanitizedInput("`foo`", "foo")
+
+    // I have no idea why anyone would do this, but make sure the result is expected
+    ensureSanitizedInput("````foo````", "`foo`")
+    ensureSanitizedInput("``foo``", "`foo`")
+  }
+
+  it should "not be sanitized" in {
+    ensureNoSanitization("foo")
+  }
+}


### PR DESCRIPTION
This prevents issues with inputs such as List[Int]()

Where combinations of []() are treated as markdown syntax

And allows the user to write ! ```List[Int]()``` instead

see the scalameta/scalameta channel for an example